### PR TITLE
Alteração para etivar interpretação errônea de caractere especial ($)…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 ./privateKey.txt
 
 bootnode/data/*
-node1/data/*
-node2/data/*
-node3/data/*
-node4/data/*
+node*
 config/bootnode_id
+config/genesis.json
 config/nodes_config.toml
 config/accounts_config.toml
 config/qbftConfigFile.json
+docker-compose.yaml

--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,7 @@ EOF
         sleep $((i*10));
         /opt/besu/bin/besu --data-path=/opt/besu/data \
         --genesis-file=/opt/besu/genesis.json --rpc-http-enabled \
-        --bootnodes=enode://\$(cat /opt/besu/config/bootnode_id)@172.16.240.30:30303 --p2p-port=30303 \
+        --bootnodes=enode://\$\$(cat /opt/besu/config/bootnode_id)@172.16.240.30:30303 --p2p-port=30303 \
         --host-allowlist="*" --rpc-http-cors-origins="all"
     volumes:
       - ./config/bootnode_id:/opt/besu/config/bootnode_id


### PR DESCRIPTION
Devido ao erro ocorrido na montagem do container, foi identificado que o caractere ($) estava sendo interpretado como um caractere especial. Em vez de usar \$(cat /opt/besu/config/bootnode_id), foi necessário dobrar o $, assim: $$. 
Isso instrui o Docker Compose a tratar o $ como parte do comando e não tentar interpretá-lo como uma interpolação de variável.

```shell
invalid interpolation format for services.node3.entrypoint.[]: "sleep 40;\n/opt/besu/bin/besu --data-path=/opt/besu/data         --genesis-file=/opt/besu/genesis.json --rpc-http-enabled         --bootnodes=enode://$(cat /opt/besu/config/bootnode_id)@172.16.240.30:30303 --p2p-port=30303         --host-allowlist=\"*\" --rpc-http-cors-origins=\"all\"\n". You may need to escape any $ with another $
```